### PR TITLE
Fix: Ensure consistent styling for workspace IDs

### DIFF
--- a/web/src/routes/workspaces/+page.svelte
+++ b/web/src/routes/workspaces/+page.svelte
@@ -182,7 +182,7 @@
                     </h3>
                     <div class="flex items-center gap-2 mt-1">
                       <span class="text-ctp-subtext1 text-xs">ID:</span>
-                      <span class="text-xs font-mono text-ctp-subtext1">
+  <span class="text-xs font-mono text-ctp-subtext1 px-2 py-1 rounded">
                         {workspace.id}
                       </span>
                     </div>


### PR DESCRIPTION
This commit updates the styling of the non-copy-able workspace ID in `web/src/routes/workspaces/+page.svelte` to visually align with the copy-able version.

The `<span>` element displaying the workspace ID for non-current workspaces now includes padding and rounded corners, matching the appearance of the copy-able ID button but without its interactive features. This ensures a more uniform look and feel across the workspace list.