### PR TITLE
Refactor: Apply Catppuccin Mocha/Latte themes

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -10,38 +10,33 @@
 */
 @layer base {
   @theme {
-    --color-gray-200: #e5e7eb;
-
-    /* Removing non-standard color in favor of standard Catppuccin colors */
-    /* --color-dark: #0a0a0f; */
-
-    /* Catppuccin Macchiato palette (Dark theme) */
-    --color-dark-ctp-base: #24273a;
-    --color-dark-ctp-mantle: #1e2030;
-    --color-dark-ctp-crust: #181926;
-    --color-dark-ctp-surface0: #363a4f;
-    --color-dark-ctp-surface1: #494d64;
-    --color-dark-ctp-surface2: #5b6078;
-    --color-dark-ctp-overlay0: #6e738d;
-    --color-dark-ctp-overlay1: #8087a2;
-    --color-dark-ctp-overlay2: #939ab7;
-    --color-dark-ctp-text: #cad3f5;
-    --color-dark-ctp-subtext0: #a5adcb;
-    --color-dark-ctp-subtext1: #b8c0e0;
-    --color-dark-ctp-lavender: #b7bdf8;
-    --color-dark-ctp-blue: #8aadf4;
-    --color-dark-ctp-sapphire: #7dc4e4;
-    --color-dark-ctp-sky: #91d7e3;
-    --color-dark-ctp-teal: #8bd5ca;
-    --color-dark-ctp-green: #a6da95;
-    --color-dark-ctp-yellow: #eed49f;
-    --color-dark-ctp-peach: #f5a97f;
-    --color-dark-ctp-maroon: #ee99a0;
-    --color-dark-ctp-red: #ed8796;
-    --color-dark-ctp-mauve: #c6a0f6;
-    --color-dark-ctp-pink: #f5bde6;
-    --color-dark-ctp-flamingo: #f0c6c6;
-    --color-dark-ctp-rosewater: #f4dbd6;
+    /* Catppuccin Mocha palette (Dark theme) */
+    --color-dark-ctp-base: #1e1e2e;
+    --color-dark-ctp-mantle: #181825;
+    --color-dark-ctp-crust: #11111b;
+    --color-dark-ctp-surface0: #313244;
+    --color-dark-ctp-surface1: #45475a;
+    --color-dark-ctp-surface2: #585b70;
+    --color-dark-ctp-overlay0: #6c7086;
+    --color-dark-ctp-overlay1: #7f849c;
+    --color-dark-ctp-overlay2: #9399b2;
+    --color-dark-ctp-text: #cdd6f4;
+    --color-dark-ctp-subtext0: #a6adc8;
+    --color-dark-ctp-subtext1: #bac2de;
+    --color-dark-ctp-lavender: #b4befe;
+    --color-dark-ctp-blue: #89b4fa;
+    --color-dark-ctp-sapphire: #74c7ec;
+    --color-dark-ctp-sky: #89dceb;
+    --color-dark-ctp-teal: #94e2d5;
+    --color-dark-ctp-green: #a6e3a1;
+    --color-dark-ctp-yellow: #f9e2af;
+    --color-dark-ctp-peach: #fab387;
+    --color-dark-ctp-maroon: #eba0ac;
+    --color-dark-ctp-red: #f38ba8;
+    --color-dark-ctp-mauve: #cba6f7;
+    --color-dark-ctp-pink: #f5c2e7;
+    --color-dark-ctp-flamingo: #f2cdcd;
+    --color-dark-ctp-rosewater: #f5e0dc;
 
     /* Catppuccin Latte palette (Light theme) */
     --color-light-ctp-base: #eff1f5;
@@ -101,7 +96,7 @@
   }
 
   .dark {
-    --color-gray-200: #374151;
+    /* --color-gray-200: #374151; /* Replaced by Catppuccin variables */
     --color-ctp-base: var(--color-dark-ctp-base);
     --color-ctp-mantle: var(--color-dark-ctp-mantle);
     --color-ctp-crust: var(--color-dark-ctp-crust);
@@ -131,7 +126,7 @@
   }
 
   .light {
-    --color-gray-200: #e5e7eb;
+    /* --color-gray-200: #e5e7eb; /* Replaced by Catppuccin variables */
     --color-ctp-base: var(--color-light-ctp-base);
     --color-ctp-mantle: var(--color-light-ctp-mantle);
     --color-ctp-crust: var(--color-light-ctp-crust);
@@ -169,6 +164,6 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--color-gray-200, currentColor);
+    border-color: var(--color-ctp-overlay2, currentColor); /* Updated to use Catppuccin Overlay2 */
   }
 }

--- a/web/src/lib/components/interactive-chart.svelte
+++ b/web/src/lib/components/interactive-chart.svelte
@@ -14,13 +14,13 @@
   >({});
   let currentTheme = $state<"light" | "dark">("dark");
 
-  const darkColors = [
-    { border: "#7dc4e4", bg: "rgba(125, 196, 228, 0.15)", point: "#b7bdf8" },
-    { border: "#f5bde6", bg: "rgba(245, 189, 230, 0.15)", point: "#ed8796" },
-    { border: "#a6da95", bg: "rgba(166, 218, 149, 0.15)", point: "#8bd5ca" },
-    { border: "#f5a97f", bg: "rgba(245, 169, 127, 0.15)", point: "#eed49f" },
-    { border: "#c6a0f6", bg: "rgba(198, 160, 246, 0.15)", point: "#8aadf4" },
-    { border: "#ed8796", bg: "rgba(237, 135, 150, 0.15)", point: "#ee99a0" },
+  const darkColors = [ // Updated to Mocha palette
+    { border: "#74c7ec", bg: "rgba(116, 199, 236, 0.15)", point: "#b4befe" }, // Sapphire, Lavender
+    { border: "#f5c2e7", bg: "rgba(245, 194, 231, 0.15)", point: "#f38ba8" }, // Pink, Red
+    { border: "#a6e3a1", bg: "rgba(166, 227, 161, 0.15)", point: "#94e2d5" }, // Green, Teal
+    { border: "#fab387", bg: "rgba(250, 179, 135, 0.15)", point: "#f9e2af" }, // Peach, Yellow
+    { border: "#cba6f7", bg: "rgba(203, 166, 247, 0.15)", point: "#89b4fa" }, // Mauve, Blue
+    { border: "#f38ba8", bg: "rgba(243, 139, 168, 0.15)", point: "#eba0ac" }, // Red, Maroon
   ];
 
   const lightColors = [
@@ -36,13 +36,15 @@
     return currentTheme === "dark" ? darkColors : lightColors;
   }
 
-  const darkThemeUI = {
-    text: "#cad3f5",
-    crust: "#181926",
-    mantle: "#1e2030",
-    base: "#24273a",
-    overlay0: "#6e738d",
-    gridLines: "rgba(183, 189, 248, 0.08)",
+  const darkThemeUI = { // Updated to Mocha palette
+    text: "#cdd6f4",
+    crust: "#11111b",
+    mantle: "#181825",
+    base: "#1e1e2e",
+    overlay0: "#6c7086",
+    gridLines: "rgba(180, 190, 254, 0.08)", // Mocha Lavender with alpha
+    mauve: "#cba6f7", 
+    sapphire: "#74c7ec",
   };
 
   const lightThemeUI = {
@@ -51,7 +53,9 @@
     mantle: "#e6e9ef",
     base: "#eff1f5",
     overlay0: "#9ca0b0",
-    gridLines: "rgba(114, 135, 253, 0.08)",
+    gridLines: "rgba(114, 135, 253, 0.08)", // Latte Lavender with alpha
+    mauve: "#8839ef",
+    sapphire: "#209fb5",
   };
 
   function getThemeUI() {
@@ -146,8 +150,7 @@
           fill: false,
           pointBackgroundColor: color.point,
           pointBorderColor: ui.mantle,
-          pointHoverBackgroundColor:
-            currentTheme === "dark" ? "#c6a0f6" : "#8839ef",
+          pointHoverBackgroundColor: ui.mauve,
           pointHoverBorderColor: ui.base,
           borderWidth: 2,
           tension: 0.3,
@@ -186,7 +189,7 @@
             },
             tooltip: {
               backgroundColor: ui.crust,
-              titleColor: currentTheme === "dark" ? "#7dc4e4" : "#209fb5",
+              titleColor: ui.sapphire,
               bodyColor: ui.text,
               borderColor: ui.overlay0,
               position: "nearest",
@@ -328,7 +331,7 @@
         <div
           class="absolute inset-0 flex items-center justify-center bg-ctp-mantle/80 backdrop-blur-sm z-10"
         >
-          <div class="animate-pulse text-[#91d7e3]">Loading data...</div>
+          <div class="animate-pulse text-ctp-sky">Loading data...</div>
         </div>
       {/if}
       <div class="absolute inset-0 p-2 sm:p-4">

--- a/web/src/routes/users/[slug]/+page.svelte
+++ b/web/src/routes/users/[slug]/+page.svelte
@@ -221,7 +221,7 @@
 
 {#if showNewKeyModal}
   <div
-    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 backdrop-blur-sm"
+    class="fixed inset-0 bg-ctp-crust/80 flex items-center justify-center z-50 backdrop-blur-sm"
     transition:fade
   >
     <div


### PR DESCRIPTION
This commit finalizes the application of Catppuccin theming with Mocha for dark mode and Latte for light mode.

Key changes:
- I updated dark theme CSS variables in `web/src/app.css` from Catppuccin Macchiato to Catppuccin Mocha values.
- I audited and refactored styles in `web/src/app.css` and Svelte components (`.svelte` files in `web/src/lib/components/` and `web/src/routes/`) to exclusively use Catppuccin CSS variables (`--color-ctp-*`).
- I removed old/unused color definitions, notably `--color-gray-200`.
- I updated `web/src/lib/components/interactive-chart.svelte` to use Mocha hex codes for its dark theme chart elements and Latte for its light theme. Some hardcoded values remain for chart lines/fills due to potential complexities with chart library CSS variable support, but they now correctly reflect the Mocha/Latte themes.
- I ensured the existing `theme-toggle.svelte` component correctly switches between the themes by adding/removing `.light` and `.dark` classes on the HTML element, which in turn activates the corresponding CSS variables.

The website should now consistently reflect the chosen Catppuccin theme across all components and pages, for both light and dark modes.