### PR TITLE
Implement CSV export for experiment metrics

### DIFF
--- a/web/src/routes/api/experiments/[slug]/metrics/csv/+server.ts
+++ b/web/src/routes/api/experiments/[slug]/metrics/csv/+server.ts
@@ -1,0 +1,29 @@
+import { error } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+  const experimentId = params.slug;
+  const userId = locals.user?.id;
+
+  try {
+    await locals.dbClient.checkExperimentAccess(experimentId, userId);
+  } catch {
+    throw error(403, "Access denied");
+  }
+
+  const metrics = await locals.dbClient.getMetrics(experimentId);
+
+  const header = "name,value,step,created_at\n";
+  const rows = metrics
+    .map((m) =>
+      [m.name, m.value, m.step ?? "", m.created_at].join(","),
+    )
+    .join("\n");
+
+  return new Response(header + rows, {
+    headers: {
+      "Content-Type": "text/csv",
+      "Content-Disposition": `attachment; filename=\"${experimentId}-metrics.csv\"`,
+    },
+  });
+};

--- a/web/src/routes/workspaces/[slug]/experiments/[experimentId]/+page.svelte
+++ b/web/src/routes/workspaces/[slug]/experiments/[experimentId]/+page.svelte
@@ -341,6 +341,13 @@
             >
               [data]
             </button>
+            <a
+              href={`/api/experiments/${experiment.id}/metrics/csv`}
+              class="text-xs text-ctp-subtext0 hover:text-ctp-blue transition-colors"
+              download
+            >
+              [csv]
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add API endpoint to download experiment metrics as CSV
- link new `[csv]` download option in experiment page

## Testing
- `pnpm run check`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684e4af760c4832dbb37c56dbd144835