### PR TITLE
Add configurable API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,7 @@ The Python logger is used to send experiment data from your training scripts to 
 **Configuration:**
 
 * The Python client is pre-configured to send data to `http://localhost:5173/api`. Ensure the Tora web application is running and accessible at this address.
-* The client uses hardcoded API keys for communication. For a local setup, the web application backend must be configured to accept these keys:
-  * `tosk_e5a828992e556642ba0d3edb097ca131a677188ef36d39dd` (for creating experiments)
-  * `tosk_f1477fb04daa14c007a2fa5159306df98d8891bb9eb37e05` (for logging metrics and other interactions)
-    How to configure these on the server side should be detailed in the web application's setup or API documentation.
+* The client now reads its API key from the environment variable `TORA_API_KEY`. If this variable is not set, it falls back to a built-in development key. Configure the web application backend to accept the key you provide via this environment variable.
 
 ### 2. Web Application (`web/`)
 
@@ -328,12 +325,8 @@ The Python client offers several ways to customize its behavior:
         ```
 
 * **API Key:**
-  * **Current Implementation:** The Python client currently uses hardcoded API keys:
-    * `tosk_e5a828992e556642ba0d3edb097ca131a677188ef36d39dd`: Used by the `Tora.create_experiment()` method.
-    * `tosk_f1477fb04daa14c007a2fa5159306df98d8891bb9eb37e05`: Used for other client requests (e.g., logging metrics) after an experiment is created or loaded.
-  * **Security Warning:** **These API keys are hardcoded in `python/tora/tora.py`. For any production, shared, or security-sensitive environment, it is crucial to make these keys configurable.** Avoid committing actual keys to version control.
-  * **Recommended Practice:** Modify the `Tora` class to read these keys from environment variables (e.g., `os.getenv("TORA_CREATE_API_KEY")`, `os.getenv("TORA_CLIENT_API_KEY")`) or a configuration file.
-  * **Server-Side:** The web application's backend (API endpoints) must be configured to recognize and validate these API keys (or the configurable ones you set up).
+  * The Python client reads its API key from the `TORA_API_KEY` environment variable. If not set, a development key is used by default.
+  * **Server-Side:** Configure the web application's backend to validate the key provided in the `x-api-key` header. Avoid committing real keys to version control.
 
 * **Log Buffer Size:**
   * The `Tora` class constructor accepts a `max_buffer_len` parameter, which defaults to `25`.

--- a/python/tora/tora.py
+++ b/python/tora/tora.py
@@ -1,8 +1,10 @@
 import httpx
+import os
 
 
 TORA_BASE_URL = "http://localhost:5173/api"
 TORA_DEV_KEY = "tosk_e5a828992e556642ba0d3edb097ca131a677188ef36d39dd"
+TORA_API_KEY = os.getenv("TORA_API_KEY", TORA_DEV_KEY)
 
 
 def hp_to_tora_format(
@@ -18,11 +20,13 @@ def hp_from_tora_format(
     return {single["key"]: single["value"] for single in hp_list}
 
 
-def create_workspace(name: str, description: str = "") -> str:
+def create_workspace(
+    name: str, description: str = "", api_key: str = TORA_API_KEY
+) -> str:
     http_client = httpx.Client(
         base_url=TORA_BASE_URL,
         headers={
-            "x-api-key": TORA_DEV_KEY,
+            "x-api-key": api_key,
             "Content-Type": "application/json",
         },
     )
@@ -43,6 +47,7 @@ class Tora:
         tags: list[str] | None = None,
         server_url: str = TORA_BASE_URL,
         max_buffer_len: int = 25,
+        api_key: str = TORA_API_KEY,
     ):
         self._experiment_id = experiment_id
         self._workspace_id = workspace_id
@@ -54,11 +59,11 @@ class Tora:
         self._http_client = httpx.Client(
             base_url=server_url,
             headers={
-                "x-api-key": TORA_DEV_KEY,
+                "x-api-key": api_key,
                 "Content-Type": "application/json",
             },
         )
-
+        
     @property
     def max_buffer_len(self) -> int:
         return self._max_buffer_len
@@ -77,6 +82,7 @@ class Tora:
         tags: list[str] | None = None,
         server_url: str = TORA_BASE_URL,
         max_buffer_len: int = 25,
+        api_key: str = TORA_API_KEY,
     ):
         data = {}
         data["name"] = name
@@ -96,7 +102,7 @@ class Tora:
             json=data,
             headers={
                 "Content-Type": "application/json",
-                "x-api-key": TORA_DEV_KEY,
+                "x-api-key": api_key,
             },
         )
         try:
@@ -112,6 +118,7 @@ class Tora:
             tags=tags,
             server_url=server_url,
             max_buffer_len=max_buffer_len,
+            api_key=api_key,
         )
 
     @classmethod
@@ -120,6 +127,7 @@ class Tora:
         experiment_id: str,
         server_url: str = "http://localhost:5173/api",
         max_buffer_len: int = 25,
+        api_key: str = TORA_API_KEY,
     ):
         req = httpx.get(url=server_url + f"/experiments/{experiment_id}")
         req.raise_for_status()
@@ -138,6 +146,7 @@ class Tora:
             tags,
             server_url,
             max_buffer_len=max_buffer_len,
+            api_key=api_key,
         )
 
     def log(self, name, value, step: int | None = None, metadata: dict | None = None):


### PR DESCRIPTION
## Summary
- add `TORA_API_KEY` env var support in Python client
- document API key configuration in README

## Testing
- `pre-commit` *(not run: no pre-commit config for this change)*

------
https://chatgpt.com/codex/tasks/task_e_684e5175f184832d8a4a401d5daa84a0