### PR TITLE
Fix API call and workspace type check

### DIFF
--- a/python/tora/tora.py
+++ b/python/tora/tora.py
@@ -129,7 +129,10 @@ class Tora:
         max_buffer_len: int = 25,
         api_key: str = TORA_API_KEY,
     ):
-        req = httpx.get(url=server_url + f"/experiments/{experiment_id}")
+        req = httpx.get(
+            url=server_url + f"/experiments/{experiment_id}",
+            headers={"x-api-key": api_key},
+        )
         req.raise_for_status()
         data = req.json()
         experiment_id = data["id"]

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -71,10 +71,10 @@ export function isWorkspace(obj: unknown): obj is Workspace {
   const w = obj as Record<string, unknown>;
   return (
     typeof w.id === "string" &&
-    typeof w.user_id === "string" &&
+    typeof w.role === "string" &&
     typeof w.name === "string" &&
-    typeof w.description === "string" &&
-    typeof w.created_at === "string"
+    (typeof w.description === "string" || w.description === null) &&
+    typeof w.createdAt === "string"
   );
 }
 


### PR DESCRIPTION
## Summary
- pass API key when loading experiments via Tora client
- correct workspace validation helper

## Testing
- `pnpm run check`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684e53a6bf14832dafb58c1e76fbf2ef