### PR TITLE
Improve chart performance and starfield efficiency

### DIFF
--- a/web/src/lib/components/starfield.svelte
+++ b/web/src/lib/components/starfield.svelte
@@ -401,10 +401,12 @@
     private starIdCounter = 0;
     private cometIdCounter = 0;
     private lastCometTime = 0;
+    private nextRecalc = 600;
     private staticStarsBuffer: p5.Graphics | null = null;
 
     constructor(p: p5) {
       this.p = p;
+      this.nextRecalc = 600;
       this.generateRealStarField();
     }
 
@@ -414,9 +416,6 @@
       this.starIdCounter = 0;
       this.cometIdCounter = 0;
 
-      console.log(
-        `Generating real starfield for New York (${NEW_YORK_LAT}, ${NEW_YORK_LON})`,
-      );
 
       const now = new Date();
       const jd = 2440587.5 + now.getTime() / 86400000;
@@ -518,8 +517,6 @@
 
       this.renderStaticStarsToBuffer();
 
-      console.log(`Visible real stars loaded: ${this.stars.length}`);
-      console.log("Star distribution:", this.getStarTypes());
     }
 
     private projectHorizonToScreen(
@@ -602,7 +599,6 @@
           this.staticStarsBuffer.circle(star.x, star.y, star.size);
         }
       }
-      console.log("Static stars pre-rendered to buffer.");
     }
 
     public update(deltaTime: number): void {
@@ -620,9 +616,9 @@
         }
       }
 
-      if (this.time % 60 < deltaTime) {
-        console.log("Recalculating real star positions...");
+      if (this.time >= this.nextRecalc) {
         this.generateRealStarField();
+        this.nextRecalc = this.time + 600;
       }
 
       if (this.time - this.lastCometTime > 15 + Math.random() * 25) {
@@ -675,7 +671,6 @@
       });
 
       this.comets.push(comet);
-      console.log(`Peaceful comet spawned: ${comet.id}`);
     }
 
     public render(): void {
@@ -699,8 +694,8 @@
     }
 
     public resize(width: number, height: number): void {
-      console.log(`Resizing starfield to ${width}x${height}`);
       this.generateRealStarField();
+      this.nextRecalc = this.time + 600;
     }
 
     public getStarCount(): number {
@@ -722,7 +717,6 @@
     try {
       const p5Module = await import("p5");
       const p5 = p5Module.default;
-      console.log("p5.js loaded for starfield");
 
       const starfieldSketch = (p: p5) => {
         let starField: StarField;

--- a/web/src/lib/server/database.ts
+++ b/web/src/lib/server/database.ts
@@ -110,9 +110,9 @@ export function createDbClient(client: SupabaseClient<Database>) {
       return timeAsync(
         "db.getExperiments",
         async () => {
-          const { data, error } = await client.rpc("get_user_experiments", {
-            workspace_id: workspaceId,
-          });
+          const { data, error } = await client
+            .rpc("get_user_experiments", { workspace_id: workspaceId })
+            .order("experiment_created_at", { ascending: false });
 
           handleError(error, "Failed to get experiments");
           return data?.map(mapRpcResultToExperiment) ?? [];

--- a/web/src/routes/workspaces/[slug]/+page.server.ts
+++ b/web/src/routes/workspaces/[slug]/+page.server.ts
@@ -18,12 +18,8 @@ export const load: PageServerLoad = async ({ locals, params, parent }) => {
   });
   const workspaceId = params.slug;
   try {
-    let experiments: Experiment[] =
+    const experiments: Experiment[] =
       await locals.dbClient.getExperiments(workspaceId);
-    experiments = experiments.sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
 
     const currentWorkspace = workspaces.find((w) => w.id === workspaceId);
     timer.end({ workspace_id: workspaceId });

--- a/web/src/routes/workspaces/[slug]/+page.svelte
+++ b/web/src/routes/workspaces/[slug]/+page.svelte
@@ -18,6 +18,7 @@
   let experiments = $state(data.experiments);
   let searchQuery = $state("");
   let debouncedQuery = $state("");
+  let debounceHandle: number | null = null;
   let highlighted = $state<string[]>([]);
   let copiedId = $state(false);
 
@@ -47,10 +48,12 @@
       .map((e) => e.exp),
   );
 
-  $effect(() => {
-    const id = setTimeout(() => (debouncedQuery = searchQuery), 200);
-    return () => clearTimeout(id);
-  });
+  function handleSearchInput() {
+    if (debounceHandle !== null) clearTimeout(debounceHandle);
+    debounceHandle = window.setTimeout(() => {
+      debouncedQuery = searchQuery;
+    }, 200);
+  }
 
   let createExperimentModal = $derived(getCreateExperimentModal());
   let editExperimentModal = $derived(getEditExperimentModal());
@@ -160,6 +163,7 @@
           type="text"
           placeholder="Search experiments..."
           bind:value={searchQuery}
+          oninput={handleSearchInput}
           class="w-full bg-ctp-surface0/20 border-0 px-4 py-3 text-ctp-text placeholder-ctp-subtext0 focus:outline-none focus:ring-1 focus:ring-ctp-text/20 transition-all font-mono text-sm"
         />
         <div

--- a/web/src/routes/workspaces/[slug]/interactive-chart.svelte
+++ b/web/src/routes/workspaces/[slug]/interactive-chart.svelte
@@ -171,8 +171,8 @@
       selectedMetricsCount: selectedMetrics.length.toString(),
     });
 
-    destroyChart();
     if (!chartCanvas || selectedMetrics.length === 0) {
+      destroyChart();
       timer.end({ skipped: "true" });
       return;
     }
@@ -219,14 +219,13 @@
         };
       });
 
-      chartInstance = new Chart(chartCanvas, {
-        type: "line",
-        data: {
-          datasets: datasets,
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
+      if (!chartInstance) {
+        chartInstance = new Chart(chartCanvas, {
+          type: "line",
+          data: { datasets },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
           parsing: false,
           normalized: true,
           events: [
@@ -368,8 +367,14 @@
               }
             },
           },
-        ],
-      });
+          ],
+        });
+      } else {
+        chartInstance.data.datasets = datasets;
+        chartInstance.update();
+        timer.end({ success: "true" });
+        return;
+      }
       timer.end({ success: "true" });
     } catch (error) {
       timer.end({


### PR DESCRIPTION
## Summary
- reuse line chart instance when updating metrics
- throttle starfield recalculation and remove noisy logs
- get experiments sorted by created date directly from the DB
- remove extra sorting on the workspace page
- debounce experiment search filtering

## Testing
- `pnpm run check`
- `pnpm exec tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684e552aa75c832d9cc6aeff0981195c