### PR TITLE
Enable experiment comparison from experiment detail

### DIFF
--- a/web/src/lib/components/toolbar.svelte
+++ b/web/src/lib/components/toolbar.svelte
@@ -30,6 +30,9 @@
     getExperimentsSelectedForComparision(),
   );
   let isWorkspacePage = $derived(page.url.pathname.startsWith("/workspaces/"));
+  let compareSupported = $derived(
+    isWorkspacePage || page.url.pathname.startsWith("/experiments/"),
+  );
   let showBackButton = $derived.by(() => {
     const path = page.url.pathname;
     return (
@@ -156,7 +159,9 @@
       >
         <Plus size={20} />
       </button>
+    {/if}
 
+    {#if compareSupported}
       {#if !isComparisonMode}
         <button
           class="p-3 rounded-full hover:bg-ctp-surface0/50 transition-all duration-200 text-ctp-subtext0 hover:text-ctp-text hover:scale-110 active:scale-95"

--- a/web/src/routes/experiments/[experimentId]/+page.svelte
+++ b/web/src/routes/experiments/[experimentId]/+page.svelte
@@ -16,6 +16,11 @@
   } from "lucide-svelte";
   import type { PageData } from "./$types";
   import InteractiveChart from "./interactive-chart.svelte";
+  import {
+    getMode,
+    addExperiment,
+    selectedForComparison,
+  } from "$lib/state/comparison.svelte.js";
 
   let { data }: { data: PageData } = $props();
   let { experiment, scalarMetrics, timeSeriesNames } = $derived(data);
@@ -24,6 +29,9 @@
     ...experiment,
     availableMetrics: timeSeriesNames,
   });
+
+  let isComparisonMode = $derived.by(() => getMode());
+  let isSelected = $derived.by(() => selectedForComparison(experiment.id));
 
   let copiedId = $state(false);
   let copiedMetric = $state<string | null>(null);
@@ -70,6 +78,10 @@
       setTimeout(() => (copiedParam = null), 1200);
     }
   }
+
+  function toggleSelection() {
+    addExperiment(experiment.id);
+  }
 </script>
 
 <div class="bg-ctp-base font-mono">
@@ -96,6 +108,14 @@
             <Globe size={12} class="text-ctp-green md:w-4 md:h-4" />
           {:else}
             <GlobeLock size={12} class="text-ctp-red md:w-4 md:h-4" />
+          {/if}
+          {#if isComparisonMode}
+            <button
+              onclick={toggleSelection}
+              class="text-xs text-ctp-{isSelected ? 'blue' : 'subtext0'} hover:text-ctp-blue transition-colors"
+            >
+              {isSelected ? "[selected]" : "[select]"}
+            </button>
           {/if}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show comparison controls on experiment pages
- allow selecting an experiment for comparison from its detail page

## Testing
- `pnpm run check`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684f316beee8832db002c0b330846d9d