### PR TITLE
Add experiment comparison modal

### DIFF
--- a/web/src/lib/components/modals/compare-experiments-modal.svelte
+++ b/web/src/lib/components/modals/compare-experiments-modal.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { X } from "lucide-svelte";
+  import type { Experiment } from "$lib/types";
+  import { closeCompareExperimentsModal } from "$lib/state/app.svelte.js";
+
+  let { experiments = $bindable(), currentId = $bindable() }:
+    { experiments: Experiment[]; currentId: string } = $props();
+
+  let selected = $state<string[]>([]);
+
+  function toggle(id: string) {
+    selected = selected.includes(id)
+      ? selected.filter((v) => v !== id)
+      : [...selected, id];
+  }
+
+  function compare() {
+    const ids = [currentId, ...selected].join(",");
+    goto(`/compare?ids=${ids}`);
+    closeCompareExperimentsModal();
+  }
+</script>
+
+<div class="fixed inset-0 bg-ctp-base/90 backdrop-blur-sm flex items-center justify-center p-4 z-50 font-mono">
+  <div class="w-full max-w-md bg-ctp-base border border-ctp-surface0/30 max-h-[90vh] overflow-auto">
+    <div class="flex items-center justify-between p-4 border-b border-ctp-surface0/20">
+      <div class="flex items-center gap-3">
+        <div class="w-2 h-6 bg-ctp-sapphire rounded-full"></div>
+        <h3 class="text-lg text-ctp-text">compare experiments</h3>
+      </div>
+      <button
+        onclick={closeCompareExperimentsModal}
+        class="text-ctp-subtext0 hover:text-ctp-red rounded p-1"
+      >
+        <X size={14} />
+      </button>
+    </div>
+    <div class="p-4 space-y-1">
+      {#each experiments as exp}
+        {#if exp.id !== currentId}
+          <label class="flex items-center gap-2 p-1 hover:bg-ctp-surface0/20 cursor-pointer text-sm">
+            <input
+              type="checkbox"
+              checked={selected.includes(exp.id)}
+              onchange={() => toggle(exp.id)}
+              class="text-ctp-blue focus:ring-ctp-blue focus:ring-1 w-3 h-3"
+            />
+            <span class="text-ctp-text truncate">{exp.name}</span>
+          </label>
+        {/if}
+      {/each}
+      {#if experiments.filter((e) => e.id !== currentId).length === 0}
+        <div class="text-sm text-ctp-subtext0 text-center">no experiments found</div>
+      {/if}
+    </div>
+    <div class="flex justify-end gap-2 p-4 border-t border-ctp-surface0/20">
+      <button
+        type="button"
+        onclick={closeCompareExperimentsModal}
+        class="bg-ctp-surface0/20 border border-ctp-surface0/30 text-ctp-subtext0 hover:text-ctp-text px-3 py-2 text-xs"
+      >
+        cancel
+      </button>
+      <button
+        type="button"
+        onclick={compare}
+        class="bg-ctp-surface0/20 border border-ctp-surface0/30 text-ctp-blue hover:text-ctp-blue px-3 py-2 text-xs {selected.length === 0 ? 'opacity-50 cursor-not-allowed' : ''}"
+        disabled={selected.length === 0}
+      >
+        compare
+      </button>
+    </div>
+  </div>
+</div>

--- a/web/src/lib/components/toolbar.svelte
+++ b/web/src/lib/components/toolbar.svelte
@@ -21,7 +21,10 @@
     getTheme,
     toggleTheme as toggleAppTheme,
   } from "$lib/state/theme.svelte.js";
-  import { openCreateExperimentModal } from "$lib/state/app.svelte.js";
+  import {
+    openCreateExperimentModal,
+    openCompareExperimentsModal,
+  } from "$lib/state/app.svelte.js";
   import { page } from "$app/state";
 
   let theme = $derived.by(() => getTheme());
@@ -30,6 +33,7 @@
     getExperimentsSelectedForComparision(),
   );
   let isWorkspacePage = $derived(page.url.pathname.startsWith("/workspaces/"));
+  let isExperimentPage = $derived(page.url.pathname.startsWith("/experiments/"));
   let showBackButton = $derived.by(() => {
     const path = page.url.pathname;
     return (
@@ -207,12 +211,24 @@
           </button>
         </div>
       {/if}
-    {/if}
+  {/if}
 
+  {#if isExperimentPage}
     <button
+      class="p-3 rounded-full hover:bg-ctp-surface0/50 transition-all duration-200 text-ctp-subtext0 hover:text-ctp-text hover:scale-110 active:scale-95"
+      title="compare experiments"
       onclick={() => {
-        toggleAppTheme();
+        openCompareExperimentsModal();
       }}
+    >
+      <GitCompareArrows size={20} />
+    </button>
+  {/if}
+
+  <button
+    onclick={() => {
+      toggleAppTheme();
+    }}
       class="p-3 rounded-full hover:bg-ctp-surface0/50 transition-all duration-200 text-ctp-subtext0 hover:text-ctp-text hover:scale-110 active:scale-95"
       aria-label={theme === "dark"
         ? "Switch to light theme"

--- a/web/src/lib/server/database.ts
+++ b/web/src/lib/server/database.ts
@@ -258,6 +258,16 @@ export function createDbClient(client: SupabaseClient<Database>) {
       handleError(error, "Failed to batch write metrics");
     },
 
+    async getWorkspaceForExperiment(id: string): Promise<string | null> {
+      const { data, error } = await client
+        .from("workspace_experiments")
+        .select("workspace_id")
+        .eq("experiment_id", id)
+        .single();
+      handleError(error, `Failed to get workspace for experiment ${id}`);
+      return data?.workspace_id ?? null;
+    },
+
     // --- Reference Methods ---
 
     async createReference(

--- a/web/src/lib/state/app.svelte.ts
+++ b/web/src/lib/state/app.svelte.ts
@@ -7,6 +7,7 @@ interface ModalState {
   deleteExperiment: Experiment | null;
   selectedExperiment: Experiment | null;
   createWorkspace: boolean;
+  compareExperiments: boolean;
 }
 
 interface AppState {
@@ -24,6 +25,7 @@ let state = $state<AppState>({
     deleteExperiment: null,
     selectedExperiment: null,
     createWorkspace: false,
+    compareExperiments: false,
   },
   ui: {
     isLoading: false,
@@ -115,10 +117,23 @@ export function getCreateWorkspaceModal() {
   return state.modals.createWorkspace;
 }
 
+export function openCompareExperimentsModal() {
+  state.modals.compareExperiments = true;
+}
+
+export function closeCompareExperimentsModal() {
+  state.modals.compareExperiments = false;
+}
+
+export function getCompareExperimentsModal() {
+  return state.modals.compareExperiments;
+}
+
 export function clearAllModals() {
   state.modals.createExperiment = false;
   state.modals.editExperiment = null;
   state.modals.deleteExperiment = null;
   state.modals.selectedExperiment = null;
   state.modals.createWorkspace = false;
+  state.modals.compareExperiments = false;
 }

--- a/web/src/routes/experiments/[experimentId]/+page.server.ts
+++ b/web/src/routes/experiments/[experimentId]/+page.server.ts
@@ -20,6 +20,12 @@ export const load: PageServerLoad = async ({ params, locals }) => {
     const data = await locals.dbClient.getExperimentsAndMetrics([
       params.experimentId,
     ]);
+    const workspaceId = await locals.dbClient.getWorkspaceForExperiment(
+      params.experimentId,
+    );
+    const workspaceExperiments = workspaceId
+      ? await locals.dbClient.getExperiments(workspaceId)
+      : [];
 
     if (!data || data.length === 0) {
       timer.end({ error: "Experiment not found" });
@@ -91,6 +97,8 @@ export const load: PageServerLoad = async ({ params, locals }) => {
       scalarMetrics,
       timeSeriesMetrics,
       timeSeriesNames,
+      workspaceId,
+      workspaceExperiments,
     };
   } catch (err) {
     timer.end({ error: err instanceof Error ? err.message : "Unknown error" });

--- a/web/src/routes/experiments/[experimentId]/+page.svelte
+++ b/web/src/routes/experiments/[experimentId]/+page.svelte
@@ -16,9 +16,13 @@
   } from "lucide-svelte";
   import type { PageData } from "./$types";
   import InteractiveChart from "./interactive-chart.svelte";
+  import CompareExperimentsModal from "$lib/components/modals/compare-experiments-modal.svelte";
+  import { getCompareExperimentsModal } from "$lib/state/app.svelte.js";
 
   let { data }: { data: PageData } = $props();
-  let { experiment, scalarMetrics, timeSeriesNames } = $derived(data);
+  let { experiment, scalarMetrics, timeSeriesNames, workspaceExperiments } =
+    $derived(data);
+  let compareModalOpen = $derived(getCompareExperimentsModal());
 
   let experimentWithMetrics = $derived({
     ...experiment,
@@ -456,3 +460,9 @@
     </div>
   </div>
 </div>
+{#if compareModalOpen}
+  <CompareExperimentsModal
+    experiments={workspaceExperiments}
+    currentId={experiment.id}
+  />
+{/if}


### PR DESCRIPTION
## Summary
- let users open a comparison modal from experiment pages
- fetch workspace experiments and expose via page data
- include workspace queries in database client

## Testing
- `pnpm run check`
- `pnpm exec tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684f353ea098832d8bea8aab24d4a6f6