### PR TITLE
Deploy web app to Cloud Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Tora provides a comprehensive ML experiment management platform with the followi
 
 **Deployment & Operations:**
 * **Cloud Deployment**: Ready-to-deploy configurations for GCP Cloud Run (secrets loaded via environment variables)
+* **Artifact Registry**: Images are pushed to `us-central1-docker.pkg.dev/$PROJECT_ID/happyplace/app` tagged with the commit SHA
 * **Docker Support**: Containerized deployment options
 * **Environment Management**: Comprehensive configuration via environment variables
 * **Migration System**: Database schema versioning with Supabase migrations

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Tora provides a comprehensive ML experiment management platform with the followi
 * **AI Analysis**: Integration endpoints for intelligent recommendations
 
 **Deployment & Operations:**
-* **Cloud Deployment**: Ready-to-deploy configurations for GCP App Engine
+* **Cloud Deployment**: Ready-to-deploy configurations for GCP Cloud Run (secrets loaded via environment variables)
 * **Docker Support**: Containerized deployment options
 * **Environment Management**: Comprehensive configuration via environment variables
 * **Migration System**: Database schema versioning with Supabase migrations
@@ -345,7 +345,7 @@ Configuration for the Svelte-based web application is primarily managed through 
   * **Essential Supabase Variables:**
     * `VITE_SUPABASE_URL`: The URL of your Supabase project.
     * `VITE_SUPABASE_ANON_KEY`: The anonymous public key for your Supabase project.
-  * **Other Variables:** Review `web/supabase/config.toml` and any cloud deployment configurations (e.g., `app.yaml`, `cloudbuild.yaml`) for other potential environment variables, especially if you plan to use features like:
+  * **Other Variables:** Review `web/supabase/config.toml` and any cloud deployment configurations (e.g., `Dockerfile`, `cloudbuild.yaml`) for other potential environment variables, especially if you plan to use features like:
     * Email services (e.g., for password resets, invitations) might require SMTP server details or API keys (e.g., `SENDGRID_API_KEY` if using SendGrid with Supabase).
     * Third-party OAuth providers (e.g., Google, GitHub) will require client IDs and secrets.
     * Specific Supabase features like `OPENAI_API_KEY` for Supabase AI.

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+supabase
+*.md
+docs

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22-bookworm-slim AS build
+FROM node:22-slim AS build
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN corepack enable && corepack prepare pnpm@8.15.5 --activate && pnpm install --frozen-lockfile
@@ -7,7 +7,7 @@ COPY . .
 RUN pnpm run build
 
 # Production stage
-FROM node:22-bookworm-slim
+FROM node:22-slim
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=build /app/build ./build

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && corepack prepare pnpm@8.15.5 --activate && pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm run build
+
+# Production stage
+FROM node:22-bookworm-slim
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/build ./build
+COPY --from=build /app/node_modules ./node_modules
+COPY package.json ./
+EXPOSE 8080
+CMD ["node", "build"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,3 @@
-# Build stage
 FROM node:22-slim AS build
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
@@ -6,7 +5,6 @@ RUN npm install -g pnpm && pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm run build
 
-# Production stage
 FROM node:22-slim
 WORKDIR /app
 ENV NODE_ENV=production

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:22-slim AS build
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN corepack enable && corepack prepare pnpm@8.15.5 --activate && pnpm install --frozen-lockfile
+RUN npm install -g pnpm && pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm run build
 

--- a/web/app.yaml
+++ b/web/app.yaml
@@ -1,2 +1,0 @@
-service: happyplace
-runtime: nodejs22

--- a/web/cloudbuild.yaml
+++ b/web/cloudbuild.yaml
@@ -1,7 +1,15 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     dir: 'web'
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/happyplace', '.']
+    args:
+      - build
+      - -t
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/happyplace/app:$COMMIT_SHA'
+      - .
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - push
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/happyplace/app:$COMMIT_SHA'
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     dir: 'web'
@@ -10,7 +18,7 @@ steps:
       - -c
       - |
         gcloud run deploy happyplace \
-          --image gcr.io/$PROJECT_ID/happyplace \
+          --image us-central1-docker.pkg.dev/$PROJECT_ID/happyplace/app:$COMMIT_SHA \
           --region us-central1 \
           --platform managed \
           --allow-unauthenticated \

--- a/web/cloudbuild.yaml
+++ b/web/cloudbuild.yaml
@@ -1,24 +1,18 @@
 steps:
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
-    dir: "web"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - |
-        # Create .env file
-        echo "Creating .env file from Secret Manager secrets"
-        echo "PUBLIC_SUPABASE_URL=$(gcloud secrets versions access latest --secret=SUPABASE_URL)" >> .env
-        echo "PUBLIC_SUPABASE_ANON_KEY=$(gcloud secrets versions access latest --secret=SUPABASE_KEY)" >> .env
-        echo "PRIVATE_ANTHROPIC_KEY=$(gcloud secrets versions access latest --secret=ANTHROPIC_KEY)" >> .env
-        echo "PRIVATE_SERVICE_ROLE_KEY=$(gcloud secrets versions access latest --secret=SUPABASE_SERVICE_KEY)" >> .env
-        echo ".env file created successfully"
+  - name: 'gcr.io/cloud-builders/docker'
+    dir: 'web'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/happyplace', '.']
 
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
-    dir: "web"
-    entrypoint: "bash"
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    dir: 'web'
+    entrypoint: bash
     args:
-      [
-        "-c",
-        "gcloud config set app/cloud_build_timeout 1600 && gcloud app deploy",
-      ]
-timeout: "1600s"
+      - -c
+      - |
+        gcloud run deploy happyplace \
+          --image gcr.io/$PROJECT_ID/happyplace \
+          --region us-central1 \
+          --platform managed \
+          --allow-unauthenticated \
+          --set-secrets PUBLIC_SUPABASE_URL=SUPABASE_URL:latest,PUBLIC_SUPABASE_ANON_KEY=SUPABASE_KEY:latest,PRIVATE_ANTHROPIC_KEY=ANTHROPIC_KEY:latest,PRIVATE_SERVICE_ROLE_KEY=SUPABASE_SERVICE_KEY:latest
+timeout: '1600s'

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -5,12 +5,9 @@ import { sequence } from "@sveltejs/kit/hooks";
 import { createDbClient } from "$lib/server/database";
 import { createHash } from "crypto";
 
-import {
-  PUBLIC_SUPABASE_URL,
-  PUBLIC_SUPABASE_ANON_KEY,
-} from "$env/static/public";
+import { env as publicEnv } from "$env/dynamic/public";
 
-import { PRIVATE_SERVICE_ROLE_KEY } from "$env/static/private";
+import { env as privateEnv } from "$env/dynamic/private";
 
 const supabase: Handle = async ({ event, resolve }) => {
   /**
@@ -19,8 +16,8 @@ const supabase: Handle = async ({ event, resolve }) => {
    * The Supabase client gets the Auth token from the request cookies.
    */
   event.locals.supabase = createServerClient(
-    PUBLIC_SUPABASE_URL,
-    PUBLIC_SUPABASE_ANON_KEY,
+    publicEnv.PUBLIC_SUPABASE_URL,
+    publicEnv.PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll: () => event.cookies.getAll(),
@@ -39,8 +36,8 @@ const supabase: Handle = async ({ event, resolve }) => {
   );
 
   event.locals.adminSupabaseClient = createClient(
-    PUBLIC_SUPABASE_URL,
-    PRIVATE_SERVICE_ROLE_KEY,
+    publicEnv.PUBLIC_SUPABASE_URL,
+    privateEnv.PRIVATE_SERVICE_ROLE_KEY,
     {
       auth: { autoRefreshToken: false, persistSession: false },
     },

--- a/web/src/lib/server/llm.ts
+++ b/web/src/lib/server/llm.ts
@@ -1,9 +1,9 @@
-import { PRIVATE_ANTHROPIC_KEY } from "$env/static/private";
+import { env } from "$env/dynamic/private";
 import Anthropic from "@anthropic-ai/sdk";
 
 export function createAnthropicClient() {
   const client = new Anthropic({
-    apiKey: PRIVATE_ANTHROPIC_KEY,
+    apiKey: env.PRIVATE_ANTHROPIC_KEY,
   });
   return client;
 }

--- a/web/src/routes/+layout.ts
+++ b/web/src/routes/+layout.ts
@@ -3,10 +3,7 @@ import {
   createServerClient,
   isBrowser,
 } from "@supabase/ssr";
-import {
-  PUBLIC_SUPABASE_ANON_KEY,
-  PUBLIC_SUPABASE_URL,
-} from "$env/static/public";
+import { env } from "$env/dynamic/public";
 import type { LayoutLoad } from "./$types";
 
 export const load: LayoutLoad = async ({ data, depends, fetch }) => {
@@ -17,12 +14,12 @@ export const load: LayoutLoad = async ({ data, depends, fetch }) => {
   depends("supabase:auth");
 
   const supabase = isBrowser()
-    ? createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+    ? createBrowserClient(env.PUBLIC_SUPABASE_URL, env.PUBLIC_SUPABASE_ANON_KEY, {
         global: {
           fetch,
         },
       })
-    : createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+    : createServerClient(env.PUBLIC_SUPABASE_URL, env.PUBLIC_SUPABASE_ANON_KEY, {
         global: {
           fetch,
         },


### PR DESCRIPTION
## Summary
- use Cloud Run in documentation for deployment
- note Dockerfile/Cloud Build when explaining extra env vars
- create Dockerfile and .dockerignore
- update Cloud Build to deploy to Cloud Run instead of App Engine

## Testing
- `pnpm run check`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685203d749f8832d84e78e490025e283